### PR TITLE
Remote Write URL

### DIFF
--- a/samples/prometheus.yaml
+++ b/samples/prometheus.yaml
@@ -13,4 +13,4 @@ spec:
       memory: 400Mi
   enableAdminAPI: false
   remoteWrite:
-  - url: 10.46.9.101:19291
+  - url: http://10.46.9.101:19291/api/v1/metrics/write

--- a/src/main/java/fakekube/io/sim/metrics/RemoteWrite.java
+++ b/src/main/java/fakekube/io/sim/metrics/RemoteWrite.java
@@ -60,7 +60,7 @@ public class RemoteWrite {
 		try {
 			HttpRequest request = HttpRequest.newBuilder()
 					.POST(buildData())
-					.uri(URI.create(String.format("http://%s/api/v1/receive", url)))
+					.uri(URI.create(url))
 					//.uri(URI.create("http://10.46.9.101:19291/write"))
 					.setHeader("User-Agent", "Java 11 HttpClient Bot") // add request header
 					.header("Content-Type", "application/x-protobuf")//"text/plain; version=0.0.4; charset=utf-8")


### PR DESCRIPTION
Use the full URL for Remote Write in the yaml file as the path can vary between servers.